### PR TITLE
Refatorado MRC, corrigido spam de zeros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test.txt
 .vscode
 DisplayMeu.hpp
 DisplayMeu.txt
+*.tmp

--- a/calculator/components/CPULucio.hpp
+++ b/calculator/components/CPULucio.hpp
@@ -24,6 +24,7 @@ class BufferDigits{
 
     void addDigit(Digit);
     void setDecimalSeparator();
+    bool getDecimalSeparator();
     void setNegative(bool);
     bool getNegative();
     void clear();
@@ -47,14 +48,14 @@ class CPULucio: public Cpu{
   private:
     Display* display;
     bool on = false;
-
+    bool memoryRead = false;
     bool treatPercentageEntry(Operator*);
     bool treatSquareRootEntry(Operator*);
 
   protected:
 
     virtual void clear();
-    virtual void clearMemory();
+    virtual void memoryReadClear(BufferDigits);
     virtual void showBuffer(BufferDigits);
     void setError(bool);
 
@@ -66,7 +67,8 @@ class CPULucio: public Cpu{
   public:
     Display* getDisplay() override;
     void setDisplay(Display*) override;
-    
+    void setMRC(bool);
+    bool getMRC();
     void receiveDigit(Digit) override;
     void receiveOperator(Operator*) override;
     void receiveControl(Control) override;

--- a/calculator/main.cpp
+++ b/calculator/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv){
 
     // TECLAS DE CONTROLE
     KeyControlLucio* keyClear = new KeyControlLucio("c", Control::CLEAR_ERROR);
-    KeyControlLucio* keyDecimalSeparator = new KeyControlLucio(",", Control::DECIMAL_SEPARATOR);
+    KeyControlLucio* keyDecimalSeparator = new KeyControlLucio(".", Control::DECIMAL_SEPARATOR);
     KeyControlLucio* keyEquals = new KeyControlLucio("=", Control::EQUAL);
     KeyControlLucio* keyMemReadClear = new KeyControlLucio("x", Control::MEMORY_READ_CLEAR);
     KeyControlLucio* keyMemSub = new KeyControlLucio("[", Control::MEMORY_SUBTRACTION);

--- a/calculator/makefile
+++ b/calculator/makefile
@@ -2,7 +2,7 @@ LIB=components/*.cpp
 V=-std=c++11
 
 all:
-	g++ main.cpp $(LIB) $(V) -g
+	g++ main.cpp $(LIB) $(V) -g -o main
 
 test:
 	g++ teste.cpp "Calculator Components/CPULucio.cpp" && clear && ./a.exe


### PR DESCRIPTION
Foi corrigido problema com spam de zeros, contudo destaca-se o problema de ao chamar o decimal separator após uma operação, as operações que ocorrem ficam confusas, aparentemente, ele força inserção apenas no buffer1, demais casos a ver: Percentage, M+, M-.